### PR TITLE
Additional config function for fixed-name tables

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ var listening = false;
 
 module.exports = ddbtest;
 module.exports.fixedName = function(test, tableName, tableDef) {
-  return ddbtest(test, tableName, tableDef);
+  var dynamo = ddbtest(test, tableName, tableDef);
+  dynamo.tableName = dynamo.tableDef.TableName = tableName;
+  return dynamo;
 };
 
 function ddbtest(test, projectName, tableDef, region) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,12 @@ var dynalite = require('dynalite')({
 
 var listening = false;
 
-module.exports = function(test, projectName, tableDef, region) {
+module.exports = ddbtest;
+module.exports.fixedName = function(test, tableName, tableDef) {
+  return ddbtest(test, tableName, tableDef);
+};
+
+function ddbtest(test, projectName, tableDef, region) {
   var live = !!region;
   tableDef = _(tableDef).clone();
 
@@ -217,4 +222,4 @@ module.exports = function(test, projectName, tableDef, region) {
   };
 
   return dynamodb;
-};
+}

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,10 @@ dynamodb.delete();
 
 Configure the `dynamodb` object by providing your own `tape` object, an arbitrary name for your project, and the JSON object that defines the table's schema. Optionally, you may specify a region. If you do, tests will be run against a live DynamoDB table in that region. If you don't, tests will be run against a local instance of [dynalite](https://github.com/mhart/dynalite). If you specify a port, dynalite will listen on it, otherwise it will use 4567.
 
+** var dynamodb = require('dynamodb-test').fixedName(tape, tableName, tableDef)**
+
+To configure a dynalite test runner with a fixed table name. 
+
 **dynamodb.dynamo**
 
 An instance of [AWS.DynamoDB](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html) configured to query your test endpoint (live or dynalite).


### PR DESCRIPTION
Use `require('dynamodb-test').fixedName()` when you need a dynalite table with a hard-wired name.
