### PR TITLE
Auto-close dynalite when tape is finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var dynalite = require('dynalite')({
 var listening = false;
 
 module.exports = ddbtest;
+module.exports.dynalite = dynalite;
 module.exports.fixedName = function(test, tableName, tableDef) {
   var dynamo = ddbtest(test, tableName, tableDef);
   dynamo.tableName = dynamo.tableDef.TableName = tableName;
@@ -33,7 +34,7 @@ function ddbtest(test, projectName, tableDef, region) {
     }, {});
   }
 
-  var dynamodb = {};
+  var dynamodb = {dynalite: dynalite};
 
   dynamodb.tableName = tableDef.TableName = [
     'test',
@@ -71,6 +72,7 @@ function ddbtest(test, projectName, tableDef, region) {
     dynalite.listen(4567, function(err) {
       if (err) throw err;
       listening = true;
+      test.onFinish(function(){ dynalite.close(); });
       dynamodb.dyno.createTable(tableDef, done);
     });
   }


### PR DESCRIPTION
Managing `dynamodb.start()` and `dynamodb.close()` across multiple files is difficult. 

- If I have `dynamodb.start()` at the beginning of each file, and `dynamodb.close()` at the end of each file, I'll get `ECONNREFUSED` on the first test in the second file. 
- Putting `dynamodb.close()` inside any test function causes an infinite hang
- Using `tape.onFinish()` creates an infinite loop, since `close()` [creates a new test](https://github.com/rclark/dynamodb-test/blob/6e033aa3965b152cc0700534e8236de2cb1711e5/index.js#L214)
- Trying `process.on('beforeExit')` or `process.on('exit')` will also hang infinitely, since [tape hijacks the regular process exit](https://github.com/substack/tape/blob/24e0a8d079ce9f68daf2ec0c00010facc383cca5/index.js#L79) to turn callback functions into serial tests
- There is no way to manually shut down the dynalite server, since it is not exposed from the module and there is no singleton
- My current solution is to make a new file called `zzzzzzzzzz-close-dynamodb.test.js` and hope that is lexicographically last across machines. 

With this PR I could delete that file since the server will shut itself down once all tests are complete. I could also extract the dynalite instance and do any necessary jiggery-pokery.